### PR TITLE
ensure asset path is relative to actual web root

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -24,7 +24,7 @@ class Theme extends Tree\Item {
 
         $fullUrl = (empty($this->assetPath) ? '' : '/').$this->assetPath.'/'.ltrim($url, '/');
 
-        if (file_exists($fullPath = base_path('public').$fullUrl))
+        if (file_exists($fullPath = $_SERVER['DOCUMENT_ROOT'].$fullUrl))
             return $fullUrl;
 
         if ($this->getParent())


### PR DESCRIPTION
The web root for a Laravel site may not be the standard /public/ directory provided in the distribution. This commit ensure that $_SERVER['DOCUMENT_ROOT'] is used as the base path when resolving the asset path in the filesystem.