### PR TITLE
Update Theme->config() for prevent throws exception on undefined conf…

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -62,9 +62,12 @@ class Theme extends Tree\Item {
      * @return mixed
      */
     public function config($key){
-        if (array_key_exists($key, $conf = \Config::get("themes.themes")[$this->name]))
-            return $conf[$key];
-
+        //root theme not have configs
+        if(array_key_exists($this->name, $confs = \Config::get("themes.themes")))
+        {
+            if (array_key_exists($key, $conf = $confs[$this->name]))
+                return $conf[$key];
+        }
         if ($this->getParent())
             return $this->getParent()->config($key);
 


### PR DESCRIPTION
…ig key

On request variable by Theme:config ($key) if $key if not defined (in themes.php) it requested from parents theme. At and of hierarchy it request config from root theme with $name='root' that not exists in config files, that throws exception.