### PR TITLE
Add ability to use an array of attributes with the img helper function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 Thumbs.db
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Some usefull helpers you can use:
 ```php
 Theme::js('file-name')
 Theme::css('file-name')
-Theme::img('src', 'alt', 'class-name')
+Theme::img('src', 'alt', 'class-name', ['attribute' => 'value'])
 ```    
 
 ## Paremeteric filenames

--- a/src/Themes.php
+++ b/src/Themes.php
@@ -175,9 +175,25 @@ class Themes{
      * @param  string $src
      * @param  string $alt
      * @param  string $Class
+     * @param  array  $attributes
      * @return string
      */
-	public function img($src, $alt='', $Class=''){
-		return '<img src="'.$this->url($src).'" alt="'.$alt.'" class="'.$Class.'">';
-	}
+    public function img($src, $alt='', $Class='', $attributes=array()){
+        return '<img src="'.$this->url($src).'" alt="'.$alt.'" class="'.$Class.'" '.$this->HtmlAttributes($attributes).'>';
+    }
+    /**
+     * Return attributes in html format
+     *
+     * @param  array $attributes
+     * @return string
+     */
+    private function HtmlAttributes($attributes){
+        $formatted = join(' ', array_map(function($key) use ($attributes){
+           if(is_bool($attributes[$key])){
+              return $attributes[$key]?$key:'';
+           }
+           return $key.'="'.$attributes[$key].'"';
+        }, array_keys($attributes)));
+        return $formatted;
+    }
 }


### PR DESCRIPTION
This will allow for greater flexibility when using the img helper function. 

For example, if you need to use name, id or other attributes with the img helper function you can now just add them as an array.

`Theme::img('/path/to/img', 'alt', 'class-name', [
    'id' => 'yourid', 
    'name' => 'yourname', 
    'width' => '200'
])`