### PR TITLE
Add a third option for handling non-existent theme files

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -52,6 +52,10 @@ class Theme extends Tree\Item {
             throw new themeException("Asset not found [$url]");
         elseif($action == 'LOG_ERROR')
             \Log::warning("Asset not found [$url] in Theme [".\Theme::get()."]");
+        elseif($action === 'ASSUME_EXISTS'){
+            $assetPath = \Theme::find(\Theme::get())->assetPath;
+            return (empty($assetPath) ? '' : '/') . $assetPath . '/' . ltrim($url, '/');
+        }
     }
 
     /**


### PR DESCRIPTION
This option assumes that the files do infact exist at that path.
This is great for e.g. route asset management (say I have /assets/file.css that actually invokes my AssetManagementController)
Or (and this one is my actual use case) you're using webpack-dev-server and so the files are stored and served in memory via a proxy.

If the asset_not_found action is 'ASSUME_EXISTS' then it will return the path relative to the active themes assetPath.