### PR TITLE
Change "vendor-as-root" to "namespace-overrides"

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -1,6 +1,7 @@
 <?php namespace igaster\laravelTheme;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 
 class Themes{
 
@@ -87,6 +88,7 @@ class Themes{
 
             $themeViewFinder = app('view.finder');
             $themeViewFinder->setPaths($paths);
+            \Event::fire('igaster.laravel-theme.change', $this->activeTheme);
     }
 
     /**

--- a/src/Themes.php
+++ b/src/Themes.php
@@ -4,15 +4,15 @@ use Illuminate\Support\Facades\Config;
 
 class Themes{
 
-	public $activeTheme = null;
-	public $root = null;
+    public $activeTheme = null;
+    public $root = null;
     private $defaultViewsPath;
     private $themesPath;
 
     public function __construct(){
-		$this->defaultViewsPath = Config::get('view.paths');
+        $this->defaultViewsPath = Config::get('view.paths');
         $this->themesPath = Config::get('themes.themes_path', null) ?: Config::get('view.paths')[0];
-		$this->root = new Theme('root','','');
+        $this->root = new Theme('root','','');
     }
 
     /**
@@ -22,15 +22,9 @@ class Themes{
      * @param   string $parentName
      * @return  \igaster\laravelTheme\Theme
      */
-	public function add(Theme $theme, $parentName = ''){
-
-		if ($parentName)
-			$parentTheme = $this->find($parentName);
-		else
-			$parentTheme = $this->root;
-
-		$theme->addParent($parentTheme);
-		return $theme;
+    public function add(Theme $theme, $parentName = ''){
+            $theme->addParent($parentName ? $this->find($parentName) : $this->root);
+            return $theme;
 	}
 
     /**
@@ -41,10 +35,7 @@ class Themes{
      */
     public function find($themeName){
         return $this->root->searchChild(function($item) use($themeName){
-            if ($item->name == $themeName)
-                return $item;
-            else
-                return false;
+            return ($item->name == $themeName ? $item : false);  
         });
     }
 
@@ -55,7 +46,7 @@ class Themes{
      * @return  bool
      */
     public function exists($themeName){
-    	return ($this->find($themeName)!==false);
+        return ($this->find($themeName) !== false);
     }
 
     /**
@@ -64,52 +55,52 @@ class Themes{
      * @param   string $themeName
      * @return  void
      */
-	public function set($themeName){
-		if (!Config::get('themes.enabled', true))
-			return;
+    public function set($themeName){
+        if (!Config::get('themes.enabled', true))
+            return;
 
-		if (!$theme = $this->find($themeName))
-			$theme = $this->add(new Theme($themeName));
+        if (!$theme = $this->find($themeName))
+            $theme = $this->add(new Theme($themeName));
 
-		$this->activeTheme = $theme;
+        $this->activeTheme = $theme;
 
-		// Build Paths array.
-		// All paths are relative to Config::get('theme.theme_path')
-		$paths = [];
-		do {
-			if(substr($theme->viewsPath, 0, 1) === DIRECTORY_SEPARATOR){
-				$path = base_path(substr($theme->viewsPath, 1));
-			} else {
-				$path = $this->themesPath;
-				$path .= empty($theme->viewsPath) ? '' : DIRECTORY_SEPARATOR . $theme->viewsPath;
-			}
-			if(!in_array($path, $paths))
-				$paths[] = $path;
-		} while ($theme = $theme->getParent());
+        // Build Paths array.
+        // All paths are relative to Config::get('theme.theme_path')
+        $paths = [];
+        do {
+            if(substr($theme->viewsPath, 0, 1) === DIRECTORY_SEPARATOR){
+                $path = base_path(substr($theme->viewsPath, 1));
+            } else {
+                $path = $this->themesPath;
+                $path .= empty($theme->viewsPath) ? '' : DIRECTORY_SEPARATOR . $theme->viewsPath;
+            }
+            if(!in_array($path, $paths))
+                $paths[] = $path;
+        } while ($theme = $theme->getParent());
 
-		// fall-back to default paths (set in views.php config file)
-		foreach ($this->defaultViewsPath as $path)
-			if(!in_array($path, $paths))
-				$paths[] = $path;
+        // fall-back to default paths (set in views.php config file)
+        foreach ($this->defaultViewsPath as $path)
+            if(!in_array($path, $paths))
+                $paths[] = $path;
 
-		Config::set('view.paths', $paths);
+            Config::set('view.paths', $paths);
 
-		$themeViewFinder = app('view.finder');
-		$themeViewFinder->setPaths($paths);
-	}
+            $themeViewFinder = app('view.finder');
+            $themeViewFinder->setPaths($paths);
+    }
 
     /**
      * Get  active's Theme Name
      *
      * @return  string
      */
-	public function get(){
-		return $this->activeTheme ? $this->activeTheme->name : '';
-	}
+    public function get(){
+        return $this->activeTheme ? $this->activeTheme->name : '';
+    }
 
-	public function current(){
-		return $this->activeTheme ? $this->activeTheme : false;
-	}
+    public function current(){
+        return $this->activeTheme ? $this->activeTheme : false;
+    }
 
     /**
      * Return current theme's configuration value for $key
@@ -117,9 +108,9 @@ class Themes{
      * @param   string $key
      * @return  mixed
      */
-	public function config($key, $defaultValue = null){
-		return $this->activeTheme->config($key, $defaultValue);
-	}
+    public function config($key, $defaultValue = null){
+        return $this->activeTheme->config($key, $defaultValue);
+    }
 
     /**
      * Set current theme's configuration value for $key
@@ -139,8 +130,8 @@ class Themes{
      * @param  string $url
      * @return string
      */
-	public function url($url){
-		if (Config::get('themes.enabled', true)){
+    public function url($url){
+        if (Config::get('themes.enabled', true)){
 
             // Check for valid {xxx} keys and replace them with the Theme's configuration value (in themes.php)
             preg_match_all('/\{(.*?)\}/', $url, $matches);
@@ -148,13 +139,13 @@ class Themes{
                 if(($value=$this->config($param)) !== null)
                     $url = str_replace('{'.$param.'}', $value, $url);
 
-			return $this->activeTheme->url($url);
+            return $this->activeTheme->url($url);
         }
-		else
-			return $url;
-	}
+        
+        return $url;
+    }
 
-	//---------------- Helper Functions (for Blade files) -------------------------
+    //---------------- Helper Functions (for Blade files) -------------------------
 
     /**
      * Return css link for $href
@@ -162,9 +153,9 @@ class Themes{
      * @param  string $href
      * @return string
      */
-	public function css($href){
-		return '<link media="all" type="text/css" rel="stylesheet" href="'.$this->url($href).'">';
-	}
+    public function css($href){
+        return '<link media="all" type="text/css" rel="stylesheet" href="'.$this->url($href).'">';
+    }
 
     /**
      * Return script link for $href
@@ -172,9 +163,9 @@ class Themes{
      * @param  string $href
      * @return string
      */
-	public function js($href){
-		return '<script src="'.$this->url($href).'"></script>';
-	}
+    public function js($href){
+        return '<script src="'.$this->url($href).'"></script>';
+    }
 
     /**
      * Return img tag

--- a/src/themeViewFinder.php
+++ b/src/themeViewFinder.php
@@ -26,10 +26,16 @@ class themeViewFinder extends FileViewFinder {
     {
         list($namespace, $view) = $this->getNamespaceSegments($name);
 
-        $rootVendors = $this->themeEngine->config('vendor-as-root', []);
-        if(in_array($namespace, $rootVendors)){
-            $vendorPath = $this->paths[0];
-        } else {
+        $namespaceOverrides = $this->themeEngine->config('namespace-overrides', []);
+        if (in_array($namespace, array_keys($namespaceOverrides))) {
+            if ($namespaceOverrides[$namespace] === '') {
+                $vendorPath = $this->paths[0];
+            } else {
+                $vendorPath = $this->paths[0] . DIRECTORY_SEPARATOR . $namespaceOverrides[$namespace];
+            }
+        }
+
+        if (!isset($vendorPath) || !$this->files->isDirectory($vendorPath)) {
             $vendorPath = $this->paths[0] . '/vendor/' . $namespace;
         }
 

--- a/src/themeViewFinder.php
+++ b/src/themeViewFinder.php
@@ -41,7 +41,7 @@ class themeViewFinder extends FileViewFinder {
 
         $hints = $this->hints[$namespace];
 
-        if (!Arr::has($hints, $vendorPath) && $this->files->isDirectory($vendorPath)) {
+        if (!in_array($vendorPath, $hints) && $this->files->isDirectory($vendorPath)) {
             $this->hints[$namespace] = Arr::prepend($hints, $vendorPath);
         }
 


### PR DESCRIPTION
Hey @igaster,

Sorry to be a pain with all these pull requests but I'm just trying to give back because this package is awesome :+1: 

Given the quantity of features I'm adding I might have a go at writing up some tests next week for us.

----

So this first change replaces the last addition I added - 

The last addition allowed you to specify that if the `$namespace` (namespace::view.name) was in the vendor-as-root array it would render it from the root theme views folder.

This allows you to instead specify overrides for where the namespaces should render to which allows for the old behaviour but also something a lot more useful.

e.g. 

```php
// /views/ in the below examples is the path to the active themes views directory
[
    'namespace-overrides' => [
        'ns-a' => ''           // view('ns-a::some.view') = /views/some/view.blade.php
        'ns-b' => 'modules'    // view('ns-b::some.view') = /views/modules/some/view.blade.php
        'ns-c' => 'sub/folder' // view('ns-c::some.view') = /views/sub/folder/some/view.blade.php
        //ns-d not in array so // view('ns-d::some.view') = /views/vendor/ns-d/some/view.blade.php
    ]
]
```
----

This second commit just tidies up the file as there was mixed tabs and spaces which was making editing it a pain.

----

The third commit adds firing an event when the theme changed so we can now do specific actions if our theme is set to be active.

----

The fourth commit fixes the custom vendor dir being added multiple times due to incorrect usage of `Arr::has`

We'll need to update the readme, But you're better than me at that so I'll leave that task to you.