### PR TITLE
providing an optional getString to url, css, js and img methods

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -132,7 +132,7 @@ class Themes{
      * @param  string $url
      * @return string
      */
-    public function url($url){
+    public function url($url, $getString = ''){
         if (Config::get('themes.enabled', true)){
 
             // Check for valid {xxx} keys and replace them with the Theme's configuration value (in themes.php)
@@ -141,10 +141,10 @@ class Themes{
                 if(($value=$this->config($param)) !== null)
                     $url = str_replace('{'.$param.'}', $value, $url);
 
-            return $this->activeTheme->url($url);
+            return $this->activeTheme->url($url.$getString);
         }
         
-        return $url;
+        return $url.$getString;
     }
 
     //---------------- Helper Functions (for Blade files) -------------------------
@@ -155,8 +155,8 @@ class Themes{
      * @param  string $href
      * @return string
      */
-    public function css($href){
-        return '<link media="all" type="text/css" rel="stylesheet" href="'.$this->url($href).'">';
+    public function css($href, $getString = ''){
+        return '<link media="all" type="text/css" rel="stylesheet" href="'.$this->url($href, $getString).'">';
     }
 
     /**
@@ -165,8 +165,8 @@ class Themes{
      * @param  string $href
      * @return string
      */
-    public function js($href){
-        return '<script src="'.$this->url($href).'"></script>';
+    public function js($href, $getString = ''){
+        return '<script src="'.$this->url($href, $getString).'"></script>';
     }
 
     /**
@@ -178,8 +178,8 @@ class Themes{
      * @param  array  $attributes
      * @return string
      */
-    public function img($src, $alt='', $Class='', $attributes=array()){
-        return '<img src="'.$this->url($src).'" alt="'.$alt.'" class="'.$Class.'" '.$this->HtmlAttributes($attributes).'>';
+    public function img($src, $alt='', $Class='', $attributes=array(), $getString = ''){
+        return '<img src="'.$this->url($src, $getString).'" alt="'.$alt.'" class="'.$Class.'" '.$this->HtmlAttributes($attributes).'>';
     }
     /**
      * Return attributes in html format


### PR DESCRIPTION
Hi, it is just an optional parameter in methods regarding URLs in order to be able to add an optional get string like "?version=1234" to the resulting HTML or URL string.
I've also done the same for branch 1.0 but not for master.