### PR TITLE
refactor(Themes.php): views-path can now be defined inside theme.json

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -189,9 +189,9 @@ class Themes{
                     $data = [];
                 }
 
-                // We already know views-path since we have scaned folders.
-                // we will overide this setting if exists
-                $data['views-path'] = $themeName;
+                if(!isset($data['views-path'])){
+                    $data['views-path'] = $themeName;
+                }
 
                 $themes[] = array_merge($defaults,$data);
             }


### PR DESCRIPTION
Up until now `views-path` could only be defined inside `config/themes.php`, but if defined within
`theme.json` it would be overriden with theme name. If you defined `theme.json` like following using `theme.json` instead of `config/themes.php`

```json
{
    "name": "themeName",
    "extends": "",
    "views-path": "themeName/views",
    "asset-path": "theme/themeName"
}
```
`views-path` would just be overriden with `themeName`. This is a problem when we want to structure theme folder like so

```
themes
│
└───themeName
    │
    └─── assets
    └─── views
```

But with this change we can define `view-path` within `theme.json` too, not only `config/themes.php`