### PR TITLE
Fix views-path override

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -175,6 +175,7 @@ class Themes{
                 $defaults = [
                     'name'          => $themeName,
                     'asset-path'    => $themeName,
+                    'views-path'    => $themeName,
                     'extends'       => null,
                 ];
 
@@ -188,10 +189,6 @@ class Themes{
                 } else {
                     $data = [];
                 }
-
-                // We already know views-path since we have scaned folders.
-                // we will overide this setting if exists
-                $data['views-path'] = $themeName;
 
                 $themes[] = array_merge($defaults,$data);
             }


### PR DESCRIPTION
https://github.com/igaster/laravel-theme/blob/master/src/Themes.php#L194 defeats the purpose of setting "views-path" in a theme.json file. What if I want my views in directory/THEME/views instead of directory/THEME? Thanks to `$data['views-path'] = $themeName;` override, it doesn't matter what is set, so it would be a lot better if that were in the defaults instead.