### PR TITLE
Use correct event facade

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -76,7 +76,7 @@ class Themes{
         $themeViewFinder = app('view.finder');
         $themeViewFinder->setPaths($paths);
 
-        \Event::fire('igaster.laravel-theme.change', $theme);
+        Event::fire('igaster.laravel-theme.change', $theme);
         return $theme;
     }
 


### PR DESCRIPTION
When the event `igaster.laravel-theme.change` was fired, it doesn't work, because of wrong namespace and an error occurs.

[Symfony\Component\Debug\Exception\FatalThrowableError]
  Call to undefined method Event::fire()

This is a fix for it.