### PR TITLE
Temp fix for asset-path being a url

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -58,11 +58,6 @@ class Theme
 
         $url = ltrim($url, '/');
 
-        // Is theme folder located on the web (ie AWS)? Dont lookup parent themes...
-        if (preg_match('/^((http(s?):)?\/\/)/i', $this->assetPath)) {
-            return $this->assetPath . '/' . $url;
-        }
-
         // Check for valid {xxx} keys and replace them with the Theme's configuration value (in themes.php)
         preg_match_all('/\{(.*?)\}/', $url, $matches);
         foreach ($matches[1] as $param) {
@@ -98,6 +93,11 @@ class Theme
             }
         }
 
+        // Is theme folder located on the web (ie AWS)? Dont lookup parent themes...
+        if (preg_match('/^((http(s?):)?\/\/)/i', $this->assetPath)) {
+            return $this->assetPath . '/' . $url;
+        }
+        
         // Asset not found at all. Error handling
         $action = Config::get('themes.asset_not_found', 'LOG_ERROR');
 


### PR DESCRIPTION
https://github.com/igaster/laravel-theme/wiki/3.-Build-your-views#parametric-filenames
Doesn't seem to work if the asset-path of a theme is a url, the return seems to be sent too early