### PR TITLE
Better compatibility with laravel-modules

### DIFF
--- a/src/themeViewFinder.php
+++ b/src/themeViewFinder.php
@@ -38,6 +38,7 @@ class themeViewFinder extends FileViewFinder
         $pathsMap = [
             // 'resources/views/vendor/mail' => 'mail',
             'resources/views/vendor' => 'vendor',
+            'resources/views/modules' => 'modules',
         ];
 
         // Does $namespace exists?


### PR DESCRIPTION
When working with laravel-modules and not selecting active theme via config.php but via Middleware (like when reading config from database), the viewHintPaths are registered before the active theme has been selected. This leads to ugly paths (with duplicated "resources/views" parts) inside the active theme folder. As the remapping of "resources/views/vendor" directory works well, we should remap the standard path for module views "resources/views/modules" as well.