### PR TITLE
Fix PHP 8.2+ deprecation warnings

### DIFF
--- a/src/Commands/baseCommand.php
+++ b/src/Commands/baseCommand.php
@@ -14,6 +14,13 @@ class baseCommand extends Command
     protected $files;
 
     /**
+     * The package tmp path.
+     *
+     * @var string
+     */
+    protected $tempPath;
+
+    /**
      * Create a new route command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files

--- a/src/themeViewFinder.php
+++ b/src/themeViewFinder.php
@@ -7,6 +7,20 @@ use Illuminate\View\FileViewFinder;
 
 class themeViewFinder extends FileViewFinder
 {
+    /**
+     * The theme engine object
+     *
+     * @var Themes
+     */
+    public $themeEngine;
+
+    /**
+     * The array of paths where the views are being searched.
+     *
+     * @var array
+     */
+    protected $paths;
+
     public function __construct(Filesystem $files, array $paths, array $extensions = null)
     {
         $this->themeEngine = \App::make('igaster.themes');


### PR DESCRIPTION
Simple fix for deprecation warning in PHP 8.2+ about using dynamic properties by defining the properties on the classes.