### PR TITLE
Fixes Conflict of @js @css with L9+

### DIFF
--- a/src/Config/themes.php
+++ b/src/Config/themes.php
@@ -2,16 +2,16 @@
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Root path where theme Views will be located.
-    | Can be outside default views path e.g.: resources/themes
-    | Leave it null if you will put your themes in the default views folder
-    | (as defined in config\views.php)
-    |--------------------------------------------------------------------------
-    */
+	/*
+	|--------------------------------------------------------------------------
+	| Root path where theme Views will be located.
+	| Can be outside default views path e.g.: resources/themes
+	| Leave it null if you will put your themes in the default views folder
+	| (as defined in config\views.php)
+	|--------------------------------------------------------------------------
+	*/
 
-    'themes_path' => null, // eg: base_path('resources/themes')
+	'themes_path' => null, // eg: base_path('resources/themes')
 
 	/*
 	|--------------------------------------------------------------------------
@@ -39,6 +39,20 @@ return [
 	*/
 
 	'cache' => false,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Laravel introduced the @js directive in Laravel 9, released on February 8, 2022.
+	| This directive was added to simplify safely passing PHP data to JavaScript
+	| within Blade templates, eliminating the need for manual JSON encoding and escaping,
+	| which was commonly done with json_encode() in older versions.
+	|
+	| which may conflict with you if you're (or package ex: filament) using it.
+	| so you might want to disabled registering this package @js @jsIn @css blade directives.
+	|--------------------------------------------------------------------------
+	*/
+
+    	'register_blade_directives' => true,
 
 	/*
 	|--------------------------------------------------------------------------

--- a/src/themeServiceProvider.php
+++ b/src/themeServiceProvider.php
@@ -87,7 +87,9 @@ class themeServiceProvider extends ServiceProvider
         | Register custom Blade Directives
         |--------------------------------------------------------------------------*/
 
-        $this->registerBladeDirectives();
+        if(\Config::get('themes.register_blade_directives', true)) {
+            $this->registerBladeDirectives();
+        }
     }
 
     protected function registerBladeDirectives()


### PR DESCRIPTION
```php
	/*
	|--------------------------------------------------------------------------
	| Laravel introduced the @js directive in Laravel 9, released on February 8, 2022.
	| This directive was added to simplify safely passing PHP data to JavaScript
	| within Blade templates, eliminating the need for manual JSON encoding and escaping,
	| which was commonly done with json_encode() in older versions.
	|
	| which may conflict with you if you're (or package ex: filament) using it.
	| so you might want to disabled registering this package @js @jsIn @css blade directives.
	|--------------------------------------------------------------------------
	*/

	'register_blade_directives' => true,
```


so when using any package using `@js` helpers or by myself using `@js` in some code, getting crash `ASSET is not defined` and `Array called on` and many many others errors, at first I didn't understand from where it's coming from, but after 2 days of debugging I found it was because of `@js` helpers and searched which packages causing it, and it was this package,
I think that's because that the package was created from L5+, 
I though of renaming it to `@themeJS`, but I see users on L9 [Commit 94fed84d](https://github.com/igaster/laravel-theme/commit/94fed84d84ca1b27959d6189bb7872110c80d299) L10 #143 L11 #145 already using it.
so this will be a breaking change for them.
So I added an option to disable it for users who have conflicts like me.
but for the feature, this must be renamed or removed.

------
# Related:
fixes #148 


-----
# Want to use this right now?
in composer.json add
```php
 "repositories": [
        {
            "type": "vcs",
            "url" :  "https://github.com/Saifallak/laravel-theme.git"
        }
    ],

```


-----
# Quick note for testing

you need to `php artisan optimize:clear` after changing this config value (idk why, but somehow laravel caches blade directives by itself, so if it was enabled, you need to clear cache and it won't be registered again)