### PR TITLE
Namespace paths

### DIFF
--- a/src/themeViewFinder.php
+++ b/src/themeViewFinder.php
@@ -65,7 +65,7 @@ class themeViewFinder extends FileViewFinder
 
         // Search $paths array and remap paths that start with a key of $pathsMap array.
         // replace with the value of $pathsMap array
-        $themeSubPaths = [];
+        $themeSubPaths = ["vendor/{$namespace}"];
         foreach ($paths as $path) {
             $pathRelativeToApp = substr($path, strlen(base_path()) + 1);
             // Ignore paths in composer installed packages (paths inside vendor folder)


### PR DESCRIPTION
The namespace paths should always allow search in the theme vendor directory. 

Currently if `/views/vendor/{namespace}` doesn't exists the paths will return only package vendor and never lookup in the theme vendor. 

Even if the `/views/vendor/{namespace}` does exists it search in `/resources/themes/{THEME_NAME}/resources/views/vendor` which is completely opposite to the documentation. Adding `$themeSubPaths = ["vendor/{$namespace}"];` in the sub paths will ensure that the theme vendor directory is added in the paths.